### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+b2
+# b2.exe
+bjam
+# bjam.exe
+bootstrap.log
+project-config.jam*


### PR DESCRIPTION
When we build Vita3K on linux, some output files are generated at `external/boost` directory. This makes the review changes process confusing and annoying because we didn't change anything in `external/boost` but `git` reports that `external/boost` has been changed.

`git clean -dfx` will not remove untracked files in submodules so we will have to `cd external/boost` to run `git clean -dfx` there to remove `boost`'s untracked files. Idealy, we should not have to care about auto-generated files.

There will be a follow up PR to Vita3K after this PR is merged.